### PR TITLE
Simple save xy update bg

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,14 @@ Mouse shortcuts:
 ```<u>```      Undo deletion of last polygon. This action will only add the latest
          removed polygon.
 
+```<h>```      Restore to original view.
+
+```<m>```      Restore last view (if the view has been zoomed, restores the
+previous view)
+
+```<i>```      Refresh view. In any case polygons or lines are not updating,
+it is possible to refresh the view.
+
 ```<e>```      Export the results. The Labelmaker creates a new segy file with the
          same headers, text content and dimensions as the input file. The segy
          file contains 0-values for all coordinates outside of any drawn

--- a/labelmaker/labelmaker.py
+++ b/labelmaker/labelmaker.py
@@ -136,7 +136,7 @@ class plotter(object):
         self.canvas.draw()
 
     def mkpoly(self, *_):
-        if len(self.x) == 0: return
+        if len(self.x) < 3: return
 
         poly = patches.Polygon(list(zip(self.x, self.y)),
                                alpha=0.5,

--- a/labelmaker/labelmaker.py
+++ b/labelmaker/labelmaker.py
@@ -72,6 +72,7 @@ class plotter(object):
                      'u': self.undo,
                      'e': self.export,
                      'z': self.undo_dot,
+                     'i': self.blit,
                      'h': self.original_view
                      }
 
@@ -142,8 +143,9 @@ class plotter(object):
         self.ax.set_ylim(self.ylim_orig)
         self.update_background()
 
-    def blit(self):
+    def blit(self, *_):
         self.fig.canvas.restore_region(self.background)
+
         self.ax.draw_artist(self.line)
 
         for poly in self.polys.keys():

--- a/labelmaker/labelmaker.py
+++ b/labelmaker/labelmaker.py
@@ -86,6 +86,7 @@ class plotter(object):
             self.canvas.mpl_connect('button_release_event', self.onrelease)
             self.canvas.mpl_connect('key_press_event', self.complete)
             self.canvas.mpl_connect('pick_event', self.onpick)
+            self.canvas.mpl_connect('resize_event', self.onresize)
 
         if self.overlaypath is not None:
             self.add_overlay(self.overlaypath)
@@ -102,6 +103,18 @@ class plotter(object):
         self.line.set_visible(x)
         for poly in self.polys.keys():
             poly.set_visible(x)
+
+    def update_background(self):
+        self.ax.clear()
+
+        self.ax.imshow(self.traces.T, aspect='auto', cmap=plt.get_cmap(self.args.cmap))
+        self.fig.canvas.draw()
+
+        self.background = self.fig.canvas.copy_from_bbox(self.fig.bbox)
+        self.blit()
+
+    def onresize(self, *_):
+        self.update_background()
 
     def blit(self):
         self.fig.canvas.restore_region(self.background)

--- a/labelmaker/labelmaker.py
+++ b/labelmaker/labelmaker.py
@@ -56,6 +56,8 @@ class plotter(object):
         self.ylim = None
         self.xlim_orig = None
         self.ylim_orig = None
+        self.xlimits = []
+        self.ylimits = []
         self.background = None
         self.x1 = None
         self.y1 = None
@@ -73,6 +75,7 @@ class plotter(object):
                      'e': self.export,
                      'z': self.undo_dot,
                      'i': self.blit,
+                     'm': self.restore_last_view,
                      'h': self.original_view
                      }
 
@@ -142,6 +145,14 @@ class plotter(object):
         self.ax.set_xlim(self.xlim_orig)
         self.ax.set_ylim(self.ylim_orig)
         self.update_background()
+        self.blit()
+
+    def restore_last_view(self, *_):
+        if not self.xlimits: return
+        self.ax.set_xlim(self.xlimits.pop())
+        self.ax.set_ylim(self.ylimits.pop())
+        self.update_background()
+        self.blit()
 
     def blit(self, *_):
         self.fig.canvas.restore_region(self.background)
@@ -157,7 +168,8 @@ class plotter(object):
     def onrelease(self, event):
         tool_mode = plt.get_current_fig_manager().toolbar.mode
         if tool_mode == "zoom rect" or tool_mode == "pan/zoom":
-            xlim_old, ylim_old = self.ax.get_xlim(), self.ax.get_ylim()
+            self.xlimits.append(self.ax.get_xlim())
+            self.ylimits.append(self.ax.get_ylim())
             # for single clicks (i.e. click release, without moving cursor): return (which is the same behavior as matplotlib)
             x, y = event.xdata, event.ydata
             if x == self.x1 or y == self.y1:
@@ -169,8 +181,8 @@ class plotter(object):
             self.update_background()
             # matplotlib will zoom after this call
             # After manually zooming the canvas, restore before zoom to allow matplot do it's own zooming
-            self.ax.set_xlim(xlim_old)
-            self.ax.set_ylim(ylim_old)
+            self.ax.set_xlim(self.xlimits[-1])
+            self.ax.set_ylim(self.ylimits[-1])
             self.fig.canvas.draw()
             return
 

--- a/labelmaker/labelmaker.py
+++ b/labelmaker/labelmaker.py
@@ -54,6 +54,9 @@ class plotter(object):
         self.overlaypath = args.compare
         self.xlim = None
         self.ylim = None
+        self.xlim_orig = None
+        self.ylim_orig = None
+        self.background = None
 
         self.polys = {}
         self.last_removed = None
@@ -66,7 +69,8 @@ class plotter(object):
                      'd': self.rmpoly,
                      'u': self.undo,
                      'e': self.export,
-                     'z': self.undo_dot
+                     'z': self.undo_dot,
+                     'h': self.original_view
                      }
 
         for key in range(1,10):
@@ -78,6 +82,7 @@ class plotter(object):
         self.ax.imshow(self.traces.T, aspect='auto', cmap=plt.get_cmap(self.args.cmap))
         self.fig.canvas.draw()
         self.xlim, self.ylim = self.ax.get_xlim(), self.ax.get_ylim()
+        self.xlim_orig, self.ylim_orig = self.ax.get_xlim(), self.ax.get_ylim()
         self.background = self.fig.canvas.copy_from_bbox(self.fig.bbox)
 
         self.line = Line2D(self.x, self.y, ls='--', c='#666666',
@@ -120,6 +125,11 @@ class plotter(object):
         self.blit()
 
     def onresize(self, *_):
+        self.update_background()
+
+    def original_view(self, *_):
+        self.ax.set_xlim(self.xlim_orig)
+        self.ax.set_ylim(self.ylim_orig)
         self.update_background()
 
     def blit(self):

--- a/labelmaker/labelmaker.py
+++ b/labelmaker/labelmaker.py
@@ -30,15 +30,15 @@ def export(fname, output, prefix = 'labelmade-'):
 
 def mkoutput(polys, shape):
     traces, samples = shape
-    output = np.zeros((traces, samples), dtype=np.single)
-    px, py = np.mgrid[0:traces, 0:samples]
+    output = np.zeros((traces, samples), dtype=np.single).T
+    px, py = np.mgrid[0:samples, 0:traces]
     points = np.c_[py.ravel(), px.ravel()]
 
     for poly, cls in polys.items():
         mask = poly.get_path().contains_points(points)
         value = cls
         np.place(output, mask, [value])
-    return output
+    return output.T
 
 class plotter(object):
     def __init__(self, args, traces):
@@ -73,7 +73,7 @@ class plotter(object):
     def run(self):
 
         self.fig, self.ax = plt.subplots()
-        self.ax.imshow(self.traces, aspect='auto', cmap=plt.get_cmap(self.args.cmap))
+        self.ax.imshow(self.traces.T, aspect='auto', cmap=plt.get_cmap(self.args.cmap))
         self.background = self.fig.canvas.copy_from_bbox(self.fig.bbox)
 
         self.line = Line2D(self.x, self.y, ls='--', c='#666666',
@@ -95,7 +95,7 @@ class plotter(object):
         with segyio.open(path) as f:
             traces = f.trace.raw[:]
 
-        self.ax.imshow(traces, aspect='auto', cmap=plt.get_cmap(self.args.cmap), alpha=0.5)
+        self.ax.imshow(traces.T, aspect='auto', cmap=plt.get_cmap(self.args.cmap), alpha=0.5)
 
     def visible(self, x):
         self.line.set_visible(x)

--- a/labelmaker/labelmaker.py
+++ b/labelmaker/labelmaker.py
@@ -52,6 +52,8 @@ class plotter(object):
         self.threshold = args.threshold
         self.traces = traces
         self.overlaypath = args.compare
+        self.xlim = None
+        self.ylim = None
 
         self.polys = {}
         self.last_removed = None
@@ -75,6 +77,7 @@ class plotter(object):
         self.fig, self.ax = plt.subplots()
         self.ax.imshow(self.traces.T, aspect='auto', cmap=plt.get_cmap(self.args.cmap))
         self.fig.canvas.draw()
+        self.xlim, self.ylim = self.ax.get_xlim(), self.ax.get_ylim()
         self.background = self.fig.canvas.copy_from_bbox(self.fig.bbox)
 
         self.line = Line2D(self.x, self.y, ls='--', c='#666666',
@@ -105,9 +108,12 @@ class plotter(object):
             poly.set_visible(x)
 
     def update_background(self):
+        self.xlim, self.ylim = self.ax.get_xlim(), self.ax.get_ylim()
         self.ax.clear()
 
         self.ax.imshow(self.traces.T, aspect='auto', cmap=plt.get_cmap(self.args.cmap))
+        self.ax.set_xlim(self.xlim)
+        self.ax.set_ylim(self.ylim)
         self.fig.canvas.draw()
 
         self.background = self.fig.canvas.copy_from_bbox(self.fig.bbox)
@@ -136,6 +142,11 @@ class plotter(object):
         if self.canvas.manager.toolbar._active is not None: return
         if event.inaxes != self.line.axes: return
         if event.button != 1: return
+
+        tool_mode = plt.get_current_fig_manager().toolbar.mode
+        if tool_mode == "zoom rect" or tool_mode == "pan/zoom":
+            self.update_background()
+            return
 
         self.x.append(event.xdata)
         self.y.append(event.ydata)

--- a/labelmaker/labelmaker.py
+++ b/labelmaker/labelmaker.py
@@ -57,6 +57,8 @@ class plotter(object):
         self.xlim_orig = None
         self.ylim_orig = None
         self.background = None
+        self.x1 = None
+        self.y1 = None
 
         self.polys = {}
         self.last_removed = None
@@ -92,6 +94,7 @@ class plotter(object):
         self.canvas = self.line.figure.canvas
         if self.overlaypath is None:
             self.canvas.mpl_connect('button_release_event', self.onrelease)
+            self.canvas.mpl_connect('button_press_event', self.onpress)
             self.canvas.mpl_connect('key_press_event', self.complete)
             self.canvas.mpl_connect('pick_event', self.onpick)
             self.canvas.mpl_connect('resize_event', self.onresize)
@@ -112,13 +115,20 @@ class plotter(object):
         for poly in self.polys.keys():
             poly.set_visible(x)
 
+    def get_zoom_limits(self, event):
+        def minmax(*args): return sorted(args)
+        x2, y2 = event.xdata, event.ydata
+        xlim = minmax(self.x1, x2)
+        ylim = minmax(self.y1, y2)
+        return xlim, ylim
+
     def update_background(self):
-        self.xlim, self.ylim = self.ax.get_xlim(), self.ax.get_ylim()
+        xlim, ylim = self.ax.get_xlim(), self.ax.get_ylim()
         self.ax.clear()
 
         self.ax.imshow(self.traces.T, aspect='auto', cmap=plt.get_cmap(self.args.cmap))
-        self.ax.set_xlim(self.xlim)
-        self.ax.set_ylim(self.ylim)
+        self.ax.set_xlim(xlim)
+        self.ax.set_ylim(ylim)
         self.fig.canvas.draw()
 
         self.background = self.fig.canvas.copy_from_bbox(self.fig.bbox)
@@ -145,7 +155,21 @@ class plotter(object):
     def onrelease(self, event):
         tool_mode = plt.get_current_fig_manager().toolbar.mode
         if tool_mode == "zoom rect" or tool_mode == "pan/zoom":
+            xlim_old, ylim_old = self.ax.get_xlim(), self.ax.get_ylim()
+            # for single clicks (i.e. click release, without moving cursor): return (which is the same behavior as matplotlib)
+            x, y = event.xdata, event.ydata
+            if x == self.x1 or y == self.y1:
+                return
+            # Update the background according to the zoom'ed area
+            xlim, ylim = self.get_zoom_limits(event)
+            self.ax.set_xlim(xlim)
+            self.ax.set_ylim(ylim)
             self.update_background()
+            # matplotlib will zoom after this call
+            # After manually zooming the canvas, restore before zoom to allow matplot do it's own zooming
+            self.ax.set_xlim(xlim_old)
+            self.ax.set_ylim(ylim_old)
+            self.fig.canvas.draw()
             return
 
         if self.pick is not None:
@@ -163,6 +187,12 @@ class plotter(object):
 
         self.line.set_data(self.x, self.y)
         self.blit()
+
+    def onpress(self, event):
+        tool_mode = plt.get_current_fig_manager().toolbar.mode
+        if tool_mode == "zoom rect":
+            self.x1, self.y1 = event.xdata, event.ydata
+            return
 
     def clear(self, *_):
         self.x, self.y = [], []

--- a/labelmaker/labelmaker.py
+++ b/labelmaker/labelmaker.py
@@ -133,6 +133,11 @@ class plotter(object):
         self.fig.canvas.flush_events()
 
     def onrelease(self, event):
+        tool_mode = plt.get_current_fig_manager().toolbar.mode
+        if tool_mode == "zoom rect" or tool_mode == "pan/zoom":
+            self.update_background()
+            return
+
         if self.pick is not None:
             if self.current_point:
                 self.move_point(event.xdata, event.ydata)
@@ -142,11 +147,6 @@ class plotter(object):
         if self.canvas.manager.toolbar._active is not None: return
         if event.inaxes != self.line.axes: return
         if event.button != 1: return
-
-        tool_mode = plt.get_current_fig_manager().toolbar.mode
-        if tool_mode == "zoom rect" or tool_mode == "pan/zoom":
-            self.update_background()
-            return
 
         self.x.append(event.xdata)
         self.y.append(event.ydata)

--- a/labelmaker/labelmaker.py
+++ b/labelmaker/labelmaker.py
@@ -106,9 +106,12 @@ class plotter(object):
     def blit(self):
         self.fig.canvas.restore_region(self.background)
         self.ax.draw_artist(self.line)
+
         for poly in self.polys.keys():
             self.ax.draw_artist(poly)
+
         self.fig.canvas.blit(self.ax.bbox)
+        self.fig.canvas.flush_events()
 
     def onrelease(self, event):
         if self.pick is not None:

--- a/labelmaker/labelmaker.py
+++ b/labelmaker/labelmaker.py
@@ -74,6 +74,7 @@ class plotter(object):
 
         self.fig, self.ax = plt.subplots()
         self.ax.imshow(self.traces.T, aspect='auto', cmap=plt.get_cmap(self.args.cmap))
+        self.fig.canvas.draw()
         self.background = self.fig.canvas.copy_from_bbox(self.fig.bbox)
 
         self.line = Line2D(self.x, self.y, ls='--', c='#666666',

--- a/labelmaker/labelmaker.py
+++ b/labelmaker/labelmaker.py
@@ -129,7 +129,7 @@ class plotter(object):
     def clear(self, *_):
         self.x, self.y = [], []
         self.line.set_data(self.x, self.y)
-        self.draw()
+        self.canvas.draw()
 
     def mkpoly(self, *_):
         if len(self.x) == 0: return


### PR DESCRIPTION
Update canvas before copy_background on zoom

Canvas must be redrawn with the new axis limits before copy_from_bbox is
called. Matplotlib will wait for release_event/press_event connected
functions have completed, and canvas must therefore be reset to allow
matplotlib's internal zoom to progress.